### PR TITLE
Updates for Mojo 24.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Once you have Mojo set up locally,
    @value
    struct Printer(HTTPService):
       fn func(self, req: HTTPRequest) raises -> HTTPResponse:
-         let body = req.body_raw
+         var body = req.body_raw
          print(String(body))
 
          return OK(body)
@@ -107,8 +107,8 @@ Once you have Mojo set up locally,
    @value
    struct ExampleRouter(HTTPService):
       fn func(self, req: HTTPRequest) raises -> HTTPResponse:
-         let body = req.body_raw
-         let uri = req.uri()
+         var body = req.body_raw
+         var uri = req.uri()
 
          if uri.path() == "/":
                print("I'm on the index path!")
@@ -131,7 +131,7 @@ Once you have Mojo set up locally,
 
    fn main() raises:
       var server = SysServer()
-      let handler = Printer()
+      var handler = Printer()
       server.listen_and_serve("0.0.0.0:8080", handler)
    ```
    Feel free to change the settings in `listen_and_serve()` to serve on a particular host and port.

--- a/bench.mojo
+++ b/bench.mojo
@@ -14,7 +14,7 @@ from external.libc import __test_socket_client__
 fn main():
     try:
         var server = SysServer()
-        let handler = TechEmpowerRouter()
+        var handler = TechEmpowerRouter()
         server.listen_and_serve("0.0.0.0:8080", handler)
     except e:
         print("Error starting server: " + e.__str__())
@@ -22,21 +22,21 @@ fn main():
 
 
 fn lightbug_benchmark_get_1req_per_conn():
-    let req_report = benchmark.run[__test_socket_client__](1, 10000, 0, 3, 100)
+    var req_report = benchmark.run[__test_socket_client__](1, 10000, 0, 3, 100)
     print("Request: ")
     req_report.print(benchmark.Unit.ns)
 
 
 fn lightbug_benchmark_server():
-    let server_report = benchmark.run[run_fake_server](max_iters=1)
+    var server_report = benchmark.run[run_fake_server](max_iters=1)
     print("Server: ")
     server_report.print(benchmark.Unit.ms)
 
 
 fn lightbug_benchmark_misc() -> None:
-    let direct_set_report = benchmark.run[init_test_and_set_a_direct](max_iters=1)
+    var direct_set_report = benchmark.run[init_test_and_set_a_direct](max_iters=1)
 
-    let recreating_set_report = benchmark.run[init_test_and_set_a_copy](max_iters=1)
+    var recreating_set_report = benchmark.run[init_test_and_set_a_copy](max_iters=1)
 
     print("Direct set: ")
     direct_set_report.print(benchmark.Unit.ms)
@@ -45,17 +45,17 @@ fn lightbug_benchmark_misc() -> None:
 
 
 fn run_fake_server():
-    let handler = FakeResponder()
-    let listener = new_fake_listener(2, getRequest)
+    var handler = FakeResponder()
+    var listener = new_fake_listener(2, getRequest)
     var server = FakeServer(listener, handler)
     server.serve()
 
 
 fn init_test_and_set_a_copy() -> None:
-    let test = TestStruct("a", "b")
-    let newtest = test.set_a_copy("c")
+    var test = TestStruct("a", "b")
+    var newtest = test.set_a_copy("c")
 
 
 fn init_test_and_set_a_direct() -> None:
     var test = TestStruct("a", "b")
-    let newtest = test.set_a_direct("c")
+    var newtest = test.set_a_direct("c")

--- a/external/libc.mojo
+++ b/external/libc.mojo
@@ -108,7 +108,7 @@ alias EWOULDBLOCK = EAGAIN
 
 fn to_char_ptr(s: String) -> Pointer[c_char]:
     """Only ASCII-based strings."""
-    let ptr = Pointer[c_char]().alloc(len(s))
+    var ptr = Pointer[c_char]().alloc(len(s))
     for i in range(len(s)):
         ptr.store(i, ord(s[i]))
     return ptr
@@ -705,8 +705,8 @@ fn inet_pton(address_family: Int, address: String) -> Int:
     if address_family == AF_INET6:
         ip_buf_size = 16
 
-    let ip_buf = Pointer[c_void].alloc(ip_buf_size)
-    let conv_status = inet_pton(
+    var ip_buf = Pointer[c_void].alloc(ip_buf_size)
+    var conv_status = inet_pton(
         rebind[c_int](address_family), to_char_ptr(address), ip_buf
     )
     return ip_buf.bitcast[c_uint]().load().to_int()
@@ -837,8 +837,8 @@ fn write(fildes: c_int, buf: Pointer[c_void], nbyte: c_size_t) -> c_int:
 
 
 fn __test_getaddrinfo__():
-    let ip_addr = "127.0.0.1"
-    let port = 8083
+    var ip_addr = "127.0.0.1"
+    var port = 8083
 
     var servinfo = Pointer[addrinfo]().alloc(1)
     servinfo.store(addrinfo())
@@ -847,40 +847,40 @@ fn __test_getaddrinfo__():
     hints.ai_family = AF_INET
     hints.ai_socktype = SOCK_STREAM
     hints.ai_flags = AI_PASSIVE
-    # let hints_ptr =
+    # var hints_ptr =
 
-    let status = getaddrinfo(
+    var status = getaddrinfo(
         to_char_ptr(ip_addr),
         Pointer[UInt8](),
         Pointer.address_of(hints),
         Pointer.address_of(servinfo),
     )
-    let msg_ptr = gai_strerror(c_int(status))
+    var msg_ptr = gai_strerror(c_int(status))
     _ = external_call["printf", c_int, Pointer[c_char], Pointer[c_char]](
         to_char_ptr("gai_strerror: %s"), msg_ptr
     )
-    let msg = c_charptr_to_string(msg_ptr)
+    var msg = c_charptr_to_string(msg_ptr)
     print("getaddrinfo satus: " + msg)
 
 
 fn __test_socket_client__():
-    let ip_addr = "127.0.0.1"  # The server's hostname or IP address
-    let port = 8080  # The port used by the server
-    let address_family = AF_INET
+    var ip_addr = "127.0.0.1"  # The server's hostname or IP address
+    var port = 8080  # The port used by the server
+    var address_family = AF_INET
 
-    let ip_buf = Pointer[c_void].alloc(4)
-    let conv_status = inet_pton(address_family, to_char_ptr(ip_addr), ip_buf)
-    let raw_ip = ip_buf.bitcast[c_uint]().load()
+    var ip_buf = Pointer[c_void].alloc(4)
+    var conv_status = inet_pton(address_family, to_char_ptr(ip_addr), ip_buf)
+    var raw_ip = ip_buf.bitcast[c_uint]().load()
 
     print("inet_pton: " + raw_ip.__str__() + " :: status: " + conv_status.__str__())
 
-    let bin_port = htons(UInt16(port))
+    var bin_port = htons(UInt16(port))
     print("htons: " + "\n" + bin_port.__str__())
 
     var ai = sockaddr_in(address_family, bin_port, raw_ip, StaticTuple[8, c_char]())
-    let ai_ptr = Pointer[sockaddr_in].address_of(ai).bitcast[sockaddr]()
+    var ai_ptr = Pointer[sockaddr_in].address_of(ai).bitcast[sockaddr]()
 
-    let sockfd = socket(address_family, SOCK_STREAM, 0)
+    var sockfd = socket(address_family, SOCK_STREAM, 0)
     if sockfd == -1:
         print("Socket creation error")
     print("sockfd: " + "\n" + sockfd.__str__())
@@ -890,15 +890,15 @@ fn __test_socket_client__():
         print("Connection error")
         return  # Ensure to exit if connection fails
 
-    let msg = to_char_ptr("Hello, world Server")
-    let bytes_sent = send(sockfd, msg, strlen(msg), 0)
+    var msg = to_char_ptr("Hello, world Server")
+    var bytes_sent = send(sockfd, msg, strlen(msg), 0)
     if bytes_sent == -1:
         print("Failed to send message")
     else:
         print("Message sent")
-    let buf_size = 1024
-    let buf = Pointer[UInt8]().alloc(buf_size)
-    let bytes_recv = recv(sockfd, buf, buf_size, 0)
+    var buf_size = 1024
+    var buf = Pointer[UInt8]().alloc(buf_size)
+    var bytes_recv = recv(sockfd, buf, buf_size, 0)
     if bytes_recv == -1:
         print("Failed to receive message")
     else:
@@ -906,33 +906,33 @@ fn __test_socket_client__():
         print(String(buf.bitcast[Int8](), bytes_recv))
 
     _ = shutdown(sockfd, SHUT_RDWR)
-    let close_status = close(sockfd)
+    var close_status = close(sockfd)
     if close_status == -1:
         print("Failed to close socket")
 
 
 fn __test_socket_server__() raises:
-    let ip_addr = "127.0.0.1"
-    let port = 8083
+    var ip_addr = "127.0.0.1"
+    var port = 8083
 
-    let address_family = AF_INET
+    var address_family = AF_INET
     var ip_buf_size = 4
     if address_family == AF_INET6:
         ip_buf_size = 16
 
-    let ip_buf = Pointer[c_void].alloc(ip_buf_size)
-    let conv_status = inet_pton(address_family, to_char_ptr(ip_addr), ip_buf)
-    let raw_ip = ip_buf.bitcast[c_uint]().load()
+    var ip_buf = Pointer[c_void].alloc(ip_buf_size)
+    var conv_status = inet_pton(address_family, to_char_ptr(ip_addr), ip_buf)
+    var raw_ip = ip_buf.bitcast[c_uint]().load()
 
     print("inet_pton: " + raw_ip.__str__() + " :: status: " + conv_status.__str__())
 
-    let bin_port = htons(UInt16(port))
+    var bin_port = htons(UInt16(port))
     print("htons: " + "\n" + bin_port.__str__())
 
     var ai = sockaddr_in(address_family, bin_port, raw_ip, StaticTuple[8, c_char]())
-    let ai_ptr = Pointer[sockaddr_in].address_of(ai).bitcast[sockaddr]()
+    var ai_ptr = Pointer[sockaddr_in].address_of(ai).bitcast[sockaddr]()
 
-    let sockfd = socket(address_family, SOCK_STREAM, 0)
+    var sockfd = socket(address_family, SOCK_STREAM, 0)
     if sockfd == -1:
         print("Socket creation error")
     print("sockfd: " + "\n" + sockfd.__str__())
@@ -968,9 +968,9 @@ fn __test_socket_server__() raises:
         + "Waiting for connections..."
     )
 
-    let their_addr_ptr = Pointer[sockaddr].alloc(1)
+    var their_addr_ptr = Pointer[sockaddr].alloc(1)
     var sin_size = socklen_t(sizeof[socklen_t]())
-    let new_sockfd = accept(
+    var new_sockfd = accept(
         sockfd, their_addr_ptr, Pointer[socklen_t].address_of(sin_size)
     )
     if new_sockfd == -1:
@@ -978,12 +978,12 @@ fn __test_socket_server__() raises:
         # close(sockfd)
         _ = shutdown(sockfd, SHUT_RDWR)
 
-    let msg = "Hello, Mojo!"
+    var msg = "Hello, Mojo!"
     if send(new_sockfd, to_char_ptr(msg).bitcast[c_void](), len(msg), 0) == -1:
         print("Failed to send response")
     print("Message sent succesfully")
     _ = shutdown(sockfd, SHUT_RDWR)
 
-    let close_status = close(new_sockfd)
+    var close_status = close(new_sockfd)
     if close_status == -1:
         print("Failed to close new_sockfd")

--- a/external/morrow.mojo
+++ b/external/morrow.mojo
@@ -10,22 +10,22 @@ alias MAX_TIMESTAMP_US = MAX_TIMESTAMP * 1_000_000
 @always_inline
 fn c_gettimeofday() -> CTimeval:
     var tv = CTimeval()
-    let p_tv = Pointer[CTimeval].address_of(tv)
+    var p_tv = Pointer[CTimeval].address_of(tv)
     external_call["gettimeofday", NoneType, Pointer[CTimeval], Int32](p_tv, 0)
     return tv
 
 
 @always_inline
 fn c_gmtime(owned tv_sec: Int) -> CTm:
-    let p_tv_sec = Pointer[Int].address_of(tv_sec)
-    let tm = external_call["gmtime", Pointer[CTm], Pointer[Int]](p_tv_sec).load()
+    var p_tv_sec = Pointer[Int].address_of(tv_sec)
+    var tm = external_call["gmtime", Pointer[CTm], Pointer[Int]](p_tv_sec).load()
     return tm
 
 
 @always_inline
 fn c_localtime(owned tv_sec: Int) -> CTm:
-    let p_tv_sec = Pointer[Int].address_of(tv_sec)
-    let tm = external_call["localtime", Pointer[CTm], Pointer[Int]](p_tv_sec).load()
+    var p_tv_sec = Pointer[Int].address_of(tv_sec)
+    var tm = external_call["localtime", Pointer[CTm], Pointer[Int]](p_tv_sec).load()
     return tm
 
 
@@ -50,7 +50,7 @@ struct TimeZone:
 
     @staticmethod
     fn local() -> TimeZone:
-        let local_t = c_localtime(0)
+        var local_t = c_localtime(0)
         return TimeZone(local_t.tm_gmtoff.to_int(), "local")
 
     @staticmethod
@@ -61,7 +61,7 @@ struct TimeZone:
             return TimeZone(0, "utc")
         var p = 3 if len(utc_str) > 3 and utc_str[0:3] == "UTC" else 0
 
-        let sign = -1 if utc_str[p] == "-" else 1
+        var sign = -1 if utc_str[p] == "-" else 1
         if utc_str[p] == "+" or utc_str[p] == "-":
             p += 1
 
@@ -71,10 +71,10 @@ struct TimeZone:
             or not isdigit(ord(utc_str[p + 1]))
         ):
             raise Error("utc_str format is invalid")
-        let hours: Int = atol(utc_str[p : p + 2])
+        var hours: Int = atol(utc_str[p : p + 2])
         p += 2
 
-        let minutes: Int
+        var minutes: Int
         if len(utc_str) <= p:
             minutes = 0
         elif len(utc_str) == p + 3 and utc_str[p] == ":":
@@ -84,20 +84,20 @@ struct TimeZone:
         else:
             minutes = 0
             raise Error("utc_str format is invalid")
-        let offset: Int = sign * (hours * 3600 + minutes * 60)
+        var offset: Int = sign * (hours * 3600 + minutes * 60)
         return TimeZone(offset)
 
     fn format(self) -> String:
-        let sign: String
-        let offset_abs: Int
+        var sign: String
+        var offset_abs: Int
         if self.offset < 0:
             sign = "-"
             offset_abs = -self.offset
         else:
             sign = "+"
             offset_abs = self.offset
-        let hh = offset_abs // 3600
-        let mm = offset_abs % 3600
+        var hh = offset_abs // 3600
+        var mm = offset_abs % 3600
         return sign + rjust(hh, 2, "0") + ":" + rjust(mm, 2, "0")
 
 
@@ -181,7 +181,7 @@ struct Morrow:
         terms of the time to include. Valid options are 'auto', 'hours',
         'minutes', 'seconds', 'milliseconds' and 'microseconds'.
         """
-        let date_str = (
+        var date_str = (
             rjust(self.year, 4, "0")
             + "-"
             + rjust(self.month, 2, "0")
@@ -230,18 +230,18 @@ struct Morrow:
 
     @staticmethod
     fn now() raises -> Self:
-        let t = c_gettimeofday()
+        var t = c_gettimeofday()
         return Self._fromtimestamp(t, False)
 
     @staticmethod
     fn utcnow() raises -> Self:
-        let t = c_gettimeofday()
+        var t = c_gettimeofday()
         return Self._fromtimestamp(t, True)
 
     @staticmethod
     fn _fromtimestamp(t: CTimeval, utc: Bool) raises -> Self:
-        let tm: CTm
-        let tz: TimeZone
+        var tm: CTm
+        var tz: TimeZone
         if utc:
             tm = c_gmtime(t.tv_sec)
             tz = TimeZone(0, "UTC")
@@ -249,7 +249,7 @@ struct Morrow:
             tm = c_localtime(t.tv_sec)
             tz = TimeZone(tm.tm_gmtoff.to_int(), "local")
 
-        let result = Self(
+        var result = Self(
             tm.tm_year.to_int() + 1900,
             tm.tm_mon.to_int() + 1,
             tm.tm_mday.to_int(),
@@ -263,14 +263,14 @@ struct Morrow:
 
     @staticmethod
     fn fromtimestamp(timestamp: Float64) raises -> Self:
-        let timestamp_ = normalize_timestamp(timestamp)
-        let t = CTimeval(timestamp_.to_int())
+        var timestamp_ = normalize_timestamp(timestamp)
+        var t = CTimeval(timestamp_.to_int())
         return Self._fromtimestamp(t, False)
 
     @staticmethod
     fn utcfromtimestamp(timestamp: Float64) raises -> Self:
-        let timestamp_ = normalize_timestamp(timestamp)
-        let t = CTimeval(timestamp_.to_int())
+        var timestamp_ = normalize_timestamp(timestamp)
+        var t = CTimeval(timestamp_.to_int())
         return Self._fromtimestamp(t, True)
 
 
@@ -306,7 +306,7 @@ fn _repeat_string(string: String, n: Int) -> String:
 
 
 fn rjust(string: String, width: Int, fillchar: String = " ") -> String:
-    let extra = width - len(string)
+    var extra = width - len(string)
     return _repeat_string(fillchar, extra) + string
 
 

--- a/lightbug.🔥
+++ b/lightbug.🔥
@@ -3,5 +3,5 @@ from lightbug_http import *
 
 fn main() raises:
     var server = SysServer()
-    let handler = Welcome()
+    var handler = Welcome()
     server.listen_and_serve("0.0.0.0:8080", handler)

--- a/lightbug_http/header.mojo
+++ b/lightbug_http/header.mojo
@@ -187,20 +187,20 @@ struct RequestHeader:
 
     # This is translated to Mojo from Golang FastHTTP
     fn parse(inout self) raises -> None:
-        let headers = self.raw_headers
+        var headers = self.raw_headers
 
         # Extract the first line (request line) and the rest of the headers
-        let first_line_and_headers = next_line(headers)
-        let request_line = first_line_and_headers.first_line
-        let rest_of_headers = first_line_and_headers.rest
+        var first_line_and_headers = next_line(headers)
+        var request_line = first_line_and_headers.first_line
+        var rest_of_headers = first_line_and_headers.rest
 
         # Parse the request line
         var n = request_line.find(" ")
         if n <= 0:
             raise Error("Cannot find HTTP request method in the request")
 
-        let method = request_line[:n]
-        let rest_of_request_line = request_line[n + 1 :]
+        var method = request_line[:n]
+        var rest_of_request_line = request_line[n + 1 :]
 
         # Defaults to HTTP/1.1
         var proto_str = String(strHttp11)
@@ -213,11 +213,11 @@ struct RequestHeader:
         elif n == 0:
             raise Error("Request URI cannot be empty")
         else:
-            let proto = rest_of_request_line[n + 1 :]
+            var proto = rest_of_request_line[n + 1 :]
             if proto != strHttp11:
                 proto_str = proto
 
-        let request_uri = rest_of_request_line[:n]
+        var request_uri = rest_of_request_line[:n]
 
         _ = self.set_method(method)
         _ = self.set_protocol(proto_str)
@@ -238,24 +238,24 @@ struct RequestHeader:
                     raise Error("Invalid header key")
 
                 if s.key[0] == "h" or s.key[0] == "H":
-                    if s.key.tolower() == "host":
+                    if s.key.lower() == "host":
                         _ = self.set_host(s.value)
                         continue
                 elif s.key[0] == "u" or s.key[0] == "U":
-                    if s.key.tolower() == "user-agent":
+                    if s.key.lower() == "user-agent":
                         _ = self.set_user_agent(s.value)
                         continue
                 elif s.key[0] == "c" or s.key[0] == "C":
-                    if s.key.tolower() == "content-type":
+                    if s.key.lower() == "content-type":
                         _ = self.set_content_type(s.value)
                         continue
-                    if s.key.tolower() == "content-length":
+                    if s.key.lower() == "content-length":
                         if self.content_length != -1:
-                            let content_length = s.value
+                            var content_length = s.value
                             self.content_length = atol(content_length)
                             self.content_length_bytes = content_length._buffer
                         continue
-                    if s.key.tolower() == "connection":
+                    if s.key.lower() == "connection":
                         if s.value == "close":
                             _ = self.set_connection_close()
                         else:
@@ -263,12 +263,12 @@ struct RequestHeader:
                             # _ = self.appendargbytes(s.key, s.value)
                         continue
                 elif s.key[0] == "t" or s.key[0] == "T":
-                    if s.key.tolower() == "transfer-encoding":
+                    if s.key.lower() == "transfer-encoding":
                         if s.value != "identity":
                             self.content_length = -1
                             # _ = self.setargbytes(s.key, strChunked)
                         continue
-                    if s.key.tolower() == "trailer":
+                    if s.key.lower() == "trailer":
                         _ = self.set_trailer(s.value)
 
                 # close connection for non-http/1.1 request unless 'Connection: keep-alive' is set.
@@ -455,7 +455,7 @@ struct ResponseHeader:
         return self.__connection_close
 
     fn parse_headers(inout self, header_str: String) raises -> None:
-        let first_line_str = header_str
+        var first_line_str = header_str
         var next = next_line(first_line_str)
         var line = next.first_line
         var rest = next.rest
@@ -469,7 +469,7 @@ struct ResponseHeader:
         if n <= 0:
             raise Error("Cannot find HTTP request method in the request")
 
-        let method = line[:n]
+        var method = line[:n]
         line = line[n + 1 :]
 
         # Defaults to HTTP/1.1
@@ -483,7 +483,7 @@ struct ResponseHeader:
         elif n == 0:
             raise Error("Request URI cannot be empty")
         else:
-            let proto = line[n + 1 :]
+            var proto = line[n + 1 :]
             if proto != strHttp11:
                 proto_str = proto
 
@@ -510,7 +510,7 @@ struct ResponseHeader:
                         continue
                     if s.key.tolower() == "content-length":
                         if self.content_length != -1:
-                            let content_length = s.value
+                            var content_length = s.value
                             self.content_length = atol(content_length)
                             self.content_length_bytes = content_length._buffer
                         continue
@@ -565,7 +565,7 @@ struct headerScanner:
             self.next_line = -1
             self.initialized = True
 
-        let bLen = len(self.b)
+        var bLen = len(self.b)
 
         if bLen >= 2 and self.b[0] == rChar[0] and self.b[1] == nChar[0]:
             self.b = self.b[2:]
@@ -584,7 +584,7 @@ struct headerScanner:
         else:
             n = self.b.find(":")
             # There can't be a \n inside the header name, check for this.
-            let x = self.b.find(nChar)
+            var x = self.b.find(nChar)
             if x < 0:
                 # A header name should always at some point be followed by a \n
                 # even if it's the one that terminates the header block.
@@ -624,10 +624,10 @@ struct headerScanner:
                 break
             if self.b[n + 1] != " " and self.b[n + 1] != "\t":
                 break
-            let d = self.b[n + 1 :].find(nChar)
+            var d = self.b[n + 1 :].find(nChar)
             if d <= 0:
                 break
-            let e = n + d + 1
+            var e = n + d + 1
             if self.b[n + 1 : e].find(":") != -1:
                 break
             is_multi_line_value = True
@@ -637,7 +637,7 @@ struct headerScanner:
             self.err = errNeedMore
             return False
 
-        let old_b = self.b
+        var old_b = self.b
         self.value = self.b[:n]
         self.subslice_len += n + 1
         self.b = self.b[n + 1 :]

--- a/lightbug_http/http.mojo
+++ b/lightbug_http/http.mojo
@@ -214,7 +214,7 @@ fn OK(body: Bytes, content_type: String) -> HTTPResponse:
 
 fn encode(res: HTTPResponse) -> Bytes:
     var res_str = String()
-    let protocol = strHttp11
+    var protocol = strHttp11
     var current_time = String()
     try:
         current_time = Morrow.utcnow().__str__()

--- a/lightbug_http/io/bytes.mojo
+++ b/lightbug_http/io/bytes.mojo
@@ -10,22 +10,22 @@ struct UnsafeString:
     var len: Int
 
     fn __init__(inout self, str: StringLiteral) -> UnsafeString:
-        let l = str.__len__()
-        let s = String(str)
-        let p = Pointer[Int8].alloc(l)
+        var l = str.__len__()
+        var s = String(str)
+        var p = Pointer[Int8].alloc(l)
         for i in range(l):
             p.store(i, s._buffer[i])
         return UnsafeString(p, l)
 
     fn __init__(str: String) -> UnsafeString:
-        let l = str.__len__()
-        let p = Pointer[Int8].alloc(l)
+        var l = str.__len__()
+        var p = Pointer[Int8].alloc(l)
         for i in range(l):
             p.store(i, str._buffer[i])
         return UnsafeString(p, l)
 
     fn to_string(self) -> String:
-        let s = String(self.data, self.len)
+        var s = String(self.data, self.len)
         return s
 
 

--- a/lightbug_http/io/fd.mojo
+++ b/lightbug_http/io/fd.mojo
@@ -17,7 +17,7 @@ struct FileDescriptor:
         self.fd = fd
 
     fn __init__(inout self, path: StringLiteral):
-        let mode: Int = 0o644  # file permission
+        var mode: Int = 0o644  # file permission
         # TODO: handle errors
         self = FileDescriptor(
             external_call["open", Int, StringLiteral, Int, Int](path, O_RDWR, mode)
@@ -27,14 +27,14 @@ struct FileDescriptor:
         _ = external_call["close", Int, Int](self.fd)
 
     fn dup(self) -> Self:
-        let new_fd = external_call["dup", Int, Int](self.fd)
+        var new_fd = external_call["dup", Int, Int](self.fd)
         return Self(new_fd)
 
     fn read(self) raises -> String:
         alias buffer_size: Int = 2**13
-        let buffer: Str
+        var buffer: Str
         with Str(size=buffer_size) as buffer:
-            let read_count: c_ssize_t = external_call[
+            var read_count: c_ssize_t = external_call[
                 "read", c_ssize_t, c_int, char_pointer, c_size_t
             ](self.fd, buffer.vector.data, buffer_size)
 
@@ -52,9 +52,9 @@ struct FileDescriptor:
             return buffer.to_string(read_count)
 
     fn write(self, data: String) raises -> Int:
-        let buffer: Str
+        var buffer: Str
         with Str(data) as buffer:
-            let write_count: c_ssize_t = external_call[
+            var write_count: c_ssize_t = external_call[
                 "write", c_ssize_t, c_int, char_pointer, c_size_t
             ](self.fd, buffer.vector.data, data.__len__())
 

--- a/lightbug_http/net.mojo
+++ b/lightbug_http/net.mojo
@@ -1,6 +1,7 @@
 from lightbug_http.strings import NetworkType
 from lightbug_http.io.bytes import Bytes
 from lightbug_http.io.sync import Duration
+from lightbug_http.sys.net import SysConnection
 
 alias default_buffer_size = 4096
 alias default_tcp_keep_alive = Duration(15 * 1000 * 1000 * 1000)  # 15 seconds
@@ -36,8 +37,7 @@ trait Listener(Movable):
     fn __init__(inout self, addr: TCPAddr) raises:
         ...
 
-    @always_inline
-    fn accept[T: Connection](self) raises -> T:
+    fn accept(borrowed self) raises -> SysConnection:
         ...
 
     fn close(self) raises:
@@ -125,7 +125,7 @@ fn resolve_internet_addr(network: String, address: String) raises -> TCPAddr:
         or network == NetworkType.udp6.value
     ):
         if address != "":
-            let host_port = split_host_port(address)
+            var host_port = split_host_port(address)
             host = host_port.host
             port = host_port.port
             portnum = atol(port.__str__())
@@ -165,14 +165,14 @@ struct HostPort:
 fn split_host_port(hostport: String) raises -> HostPort:
     var host: String = ""
     var port: String = ""
-    let colon_index = hostport.rfind(":")
+    var colon_index = hostport.rfind(":")
     var j: Int = 0
     var k: Int = 0
 
     if colon_index == -1:
         raise missingPortError
     if hostport[0] == "[":
-        let end_bracket_index = hostport.find("]")
+        var end_bracket_index = hostport.find("]")
         if end_bracket_index == -1:
             raise Error("missing ']' in address")
         if end_bracket_index + 1 == len(hostport):

--- a/lightbug_http/python/__init__.mojo
+++ b/lightbug_http/python/__init__.mojo
@@ -12,10 +12,10 @@ struct Modules:
 
     @staticmethod
     fn __load_socket() raises -> PythonObject:
-        let socket = Python.import_module("socket")
+        var socket = Python.import_module("socket")
         return socket
 
     @staticmethod
     fn __load_builtins() raises -> PythonObject:
-        let builtins = Python.import_module("builtins")
+        var builtins = Python.import_module("builtins")
         return builtins

--- a/lightbug_http/python/client.mojo
+++ b/lightbug_http/python/client.mojo
@@ -34,7 +34,7 @@ struct PythonClient(Client):
         except e:
             print("error parsing uri: " + e.__str__())
 
-        let host = String(uri.host())
+        var host = String(uri.host())
 
         if host == "":
             raise Error("URI is nil")
@@ -42,19 +42,19 @@ struct PythonClient(Client):
         if uri.is_https():
             is_tls = True
 
-        let host_port = host.split(":")
-        let host_str = host_port[0]
+        var host_port = host.split(":")
+        var host_str = host_port[0]
 
-        let port = atol(host_port[1])
+        var port = atol(host_port[1])
 
         _ = self.socket.connect((UnsafeString(host_str), port))
 
-        let data = self.pymodules.builtins.bytes(
+        var data = self.pymodules.builtins.bytes(
             String(req.body_raw), CharSet.utf8.value
         )
         _ = self.socket.sendall(data)
 
-        let res = self.socket.recv(1024).decode()
+        var res = self.socket.recv(1024).decode()
         _ = self.socket.close()
 
         return HTTPResponse(res.__str__()._buffer)

--- a/lightbug_http/python/net.mojo
+++ b/lightbug_http/python/net.mojo
@@ -36,7 +36,7 @@ struct PythonTCPListener(Listener):
 
     @always_inline
     fn accept[T: Connection](self) raises -> T:
-        let conn_addr = self.socket.accept()
+        var conn_addr = self.socket.accept()
         return PythonConnection(self.__pymodules, conn_addr)
 
     fn close(self) raises:
@@ -61,7 +61,7 @@ struct PythonListenConfig(ListenConfig):
         self.__pymodules = Modules()
 
     fn listen(inout self, network: String, address: String) raises -> PythonTCPListener:
-        let addr = resolve_internet_addr(network, address)
+        var addr = resolve_internet_addr(network, address)
         var listener = PythonTCPListener(self.__pymodules.builtins, addr)
         listener.socket = self.__pymodules.socket.socket(
             self.__pymodules.socket.AF_INET,
@@ -99,14 +99,14 @@ struct PythonConnection(Connection):
         self.pymodules = pymodules
 
     fn read(self, inout buf: Bytes) raises -> Int:
-        let data = self.conn.recv(default_buffer_size)
+        var data = self.conn.recv(default_buffer_size)
         buf = String(
             self.pymodules.bytes.decode(data, CharSet.utf8.value).__str__()
         )._buffer
         return len(buf)
 
     fn write(self, buf: Bytes) raises -> Int:
-        let data = self.pymodules.bytes(String(buf), CharSet.utf8.value)
+        var data = self.pymodules.bytes(String(buf), CharSet.utf8.value)
         _ = self.conn.sendall(data)
         return len(buf)
 

--- a/lightbug_http/python/server.mojo
+++ b/lightbug_http/python/server.mojo
@@ -55,24 +55,24 @@ struct PythonServer:
         T: HTTPService
     ](inout self, address: String, handler: T) raises -> None:
         var __net = PythonNet()
-        let listener = __net.listen(NetworkType.tcp4.value, address)
+        var listener = __net.listen(NetworkType.tcp4.value, address)
         self.serve(listener, handler)
 
     fn serve[
         T: HTTPService
     ](inout self, ln: PythonTCPListener, handler: T) raises -> None:
-        # let max_worker_count = self.get_concurrency()
+        # var max_worker_count = self.get_concurrency()
         # TODO: logic for non-blocking read and write here, see for example https://github.com/valyala/fasthttp/blob/9ba16466dfd5d83e2e6a005576ee0d8e127457e2/server.go#L1789
 
         self.ln = ln
 
         while True:
-            let conn = self.ln.accept[PythonConnection]()
+            var conn = self.ln.accept[PythonConnection]()
             var buf = Bytes()
-            let read_len = conn.read(buf)
-            let first_line_and_headers = next_line(buf)
-            let request_line = first_line_and_headers.first_line
-            let rest_of_headers = first_line_and_headers.rest
+            var read_len = conn.read(buf)
+            var first_line_and_headers = next_line(buf)
+            var request_line = first_line_and_headers.first_line
+            var rest_of_headers = first_line_and_headers.rest
 
             var uri = URI(request_line)
             try:
@@ -88,13 +88,13 @@ struct PythonServer:
                 conn.close()
                 raise Error("Failed to parse request header")
 
-            let res = handler.func(
+            var res = handler.func(
                 HTTPRequest(
                     uri,
                     buf,
                     header,
                 )
             )
-            let res_encoded = encode(res)
+            var res_encoded = encode(res)
             _ = conn.write(res_encoded)
             conn.close()

--- a/lightbug_http/service.mojo
+++ b/lightbug_http/service.mojo
@@ -9,7 +9,7 @@ trait HTTPService:
 @value
 struct Printer(HTTPService):
     fn func(self, req: HTTPRequest) raises -> HTTPResponse:
-        let body = req.body_raw
+        var body = req.body_raw
         print(String(body))
 
         return OK(body)
@@ -18,7 +18,7 @@ struct Printer(HTTPService):
 @value
 struct Welcome(HTTPService):
     fn func(self, req: HTTPRequest) raises -> HTTPResponse:
-        let html: String
+        var html: String
         with open("static/lightbug_welcome.html", "r") as f:
             html = f.read()
 
@@ -28,8 +28,8 @@ struct Welcome(HTTPService):
 @value
 struct ExampleRouter(HTTPService):
     fn func(self, req: HTTPRequest) raises -> HTTPResponse:
-        let body = req.body_raw
-        let uri = req.uri()
+        var body = req.body_raw
+        var uri = req.uri()
 
         if uri.path() == "/":
             print("I'm on the index path!")
@@ -46,8 +46,8 @@ struct ExampleRouter(HTTPService):
 @value
 struct TechEmpowerRouter(HTTPService):
     fn func(self, req: HTTPRequest) raises -> HTTPResponse:
-        let body = req.body_raw
-        let uri = req.uri()
+        var body = req.body_raw
+        var uri = req.uri()
 
         if uri.path() == "/plaintext":
             return OK(String("Hello, World!")._buffer, "text/plain")

--- a/lightbug_http/strings.mojo
+++ b/lightbug_http/strings.mojo
@@ -25,7 +25,7 @@ struct TwoLines:
 
 # Helper function to get the next line
 fn next_line(s: String) raises -> TwoLines:
-    let split = s.split("\n")
+    var split = s.split("\n")
     return TwoLines(split[0].strip(), split[1]) if len(split) == 2 else TwoLines(
         split[0].strip(), String()
     )

--- a/lightbug_http/sys/server.mojo
+++ b/lightbug_http/sys/server.mojo
@@ -51,22 +51,22 @@ struct SysServer:
         T: HTTPService
     ](inout self, address: String, handler: T) raises -> None:
         var __net = SysNet()
-        let listener = __net.listen(NetworkType.tcp4.value, address)
+        var listener = __net.listen(NetworkType.tcp4.value, address)
         self.serve(listener, handler)
 
     fn serve[T: HTTPService](inout self, ln: SysListener, handler: T) raises -> None:
-        # let max_worker_count = self.get_concurrency()
+        # var max_worker_count = self.get_concurrency()
         # TODO: logic for non-blocking read and write here, see for example https://github.com/valyala/fasthttp/blob/9ba16466dfd5d83e2e6a005576ee0d8e127457e2/server.go#L1789
 
         self.ln = ln
 
         while True:
-            let conn = self.ln.accept[SysConnection]()
+            var conn = self.ln.accept()
             var buf = Bytes()
-            let read_len = conn.read(buf)
-            let first_line_and_headers = next_line(buf)
-            let request_line = first_line_and_headers.first_line
-            let rest_of_headers = first_line_and_headers.rest
+            var read_len = conn.read(buf)
+            var first_line_and_headers = next_line(buf)
+            var request_line = first_line_and_headers.first_line
+            var rest_of_headers = first_line_and_headers.rest
 
             var uri = URI(request_line)
             try:
@@ -82,13 +82,13 @@ struct SysServer:
                 conn.close()
                 raise Error("Failed to parse request header")
 
-            let res = handler.func(
+            var res = handler.func(
                 HTTPRequest(
                     uri,
                     buf,
                     header,
                 )
             )
-            let res_encoded = encode(res)
+            var res_encoded = encode(res)
             _ = conn.write(res_encoded)
             conn.close()

--- a/lightbug_http/tests/run.mojo
+++ b/lightbug_http/tests/run.mojo
@@ -8,8 +8,8 @@ fn run_tests() raises:
 
 
 fn run_client_tests() raises:
-    let fake_client = FakeClient()
-    let py_client = PythonClient()
+    var fake_client = FakeClient()
+    var py_client = PythonClient()
     test_client_lightbug[FakeClient](fake_client)
     test_client_lightbug[PythonClient](py_client)
 

--- a/lightbug_http/tests/test_client.mojo
+++ b/lightbug_http/tests/test_client.mojo
@@ -11,7 +11,7 @@ from lightbug_http.tests.utils import (
 
 
 fn test_client_lightbug[T: Client](client: T) raises:
-    let res = client.do(
+    var res = client.do(
         HTTPRequest(
             URI(default_server_conn_string),
             String("Hello world!")._buffer,
@@ -29,8 +29,8 @@ fn test_request_simple_url[T: Client](inout client: T) raises -> None:
     Test making a simple GET request without parameters.
     Validate that we get a 200 OK response.
     """
-    let uri = URI("http", "localhost", "/123")
-    let response = client.do(HTTPRequest(uri))
+    var uri = URI("http", "localhost", "/123")
+    var response = client.do(HTTPRequest(uri))
     testing.assert_equal(response.header.status_code(), 200)
 
 
@@ -40,10 +40,10 @@ fn test_request_simple_url_with_parameters[T: Client](inout client: T) raises ->
     Validate that we get a 200 OK response and that server can parse the query parameters.
     """
     # This test is a WIP
-    let uri = URI("http", "localhost", "/123")
+    var uri = URI("http", "localhost", "/123")
     # uri.add_query_parameter("foo", "bar")
     # uri.add_query_parameter("baz", "qux")
-    let response = client.do(HTTPRequest(uri))
+    var response = client.do(HTTPRequest(uri))
     testing.assert_equal(response.header.status_code(), 200)
 
 
@@ -52,10 +52,10 @@ fn test_request_simple_url_with_headers[T: Client](inout client: T) raises -> No
     WIP: Test making a simple GET request with headers.
     Validate that we get a 200 OK response and that server can parse the headers.
     """
-    let uri = URI("http", "localhost", "/123")
-    let request = HTTPRequest(uri)
+    var uri = URI("http", "localhost", "/123")
+    var request = HTTPRequest(uri)
     # request.header.add("foo", "bar")
-    let response = client.do(request)
+    var response = client.do(request)
     testing.assert_equal(response.header.status_code(), 200)
 
 
@@ -64,10 +64,10 @@ fn test_request_post_plain_text[T: Client](inout client: T) raises -> None:
     WIP: Test making a POST request with PLAIN TEXT body.
     Validate that request is properly received and the server can parse the body.
     """
-    let uri = URI("http", "localhost", "/123")
-    let request = HTTPRequest(uri)
+    var uri = URI("http", "localhost", "/123")
+    var request = HTTPRequest(uri)
     # request.body = "Hello World"
-    # let response = client.post(request)
+    # var response = client.post(request)
     # testing.assert_equal(response.header.status_code(), 200)
 
 
@@ -76,10 +76,10 @@ fn test_request_post_json[T: Client](inout client: T) raises -> None:
     WIP: Test making a POST request with JSON body.
     Validate that the request is properly received and the server can parse the JSON.
     """
-    let uri = URI("http", "localhost", "/123")
-    let request = HTTPRequest(uri)
+    var uri = URI("http", "localhost", "/123")
+    var request = HTTPRequest(uri)
     # request.body = "{\"foo\": \"bar\"}"
-    # let response = client.post(request)
+    # var response = client.post(request)
     # testing.assert_equal(response.header.status_code(), 200)
 
 
@@ -89,10 +89,10 @@ fn test_request_post_form[T: Client](inout client: T) raises -> None:
     Validate that the request is properly received and the server can parse the form.
     Include URL encoded strings in test cases.
     """
-    let uri = URI("http", "localhost", "/123")
-    let request = HTTPRequest(uri)
+    var uri = URI("http", "localhost", "/123")
+    var request = HTTPRequest(uri)
     # request.body = "foo=bar&baz=qux"
-    # let response = client.post(request)
+    # var response = client.post(request)
     # testing.assert_equal(response.header.status_code(), 200)
 
 
@@ -101,10 +101,10 @@ fn test_request_post_file[T: Client](inout client: T) raises -> None:
     WIP: Test making a POST request with a FILE body.
     Validate that the request is properly received and the server can parse the body.
     """
-    let uri = URI("http", "localhost", "/123")
-    let request = HTTPRequest(uri)
+    var uri = URI("http", "localhost", "/123")
+    var request = HTTPRequest(uri)
     # request.body = "foo=bar&baz=qux"
-    # let response = client.post(request)
+    # var response = client.post(request)
     # testing.assert_equal(response.header.status_code(), 200)
 
 
@@ -114,10 +114,10 @@ fn test_request_post_stream[T: Client](inout client: T) raises -> None:
     Validate that the request is properly received and the server can parse the body.
     Try stream only, stream then body, and body then stream.
     """
-    let uri = URI("http", "localhost", "/123")
-    let request = HTTPRequest(uri)
+    var uri = URI("http", "localhost", "/123")
+    var request = HTTPRequest(uri)
     # request.body = "foo=bar&baz=qux"
-    # let response = client.post(request)
+    # var response = client.post(request)
     # testing.assert_equal(response.header.status_code(), 200)
 
 
@@ -126,10 +126,10 @@ fn test_request_put[T: Client](inout client: T) raises -> None:
     WIP: Test making a PUT request.
     Validate that the PUT request is properly received and the server can parse the body.
     """
-    let uri = URI("http", "localhost", "/123")
-    let request = HTTPRequest(uri)
+    var uri = URI("http", "localhost", "/123")
+    var request = HTTPRequest(uri)
     # request.body = "foo=bar&baz=qux"
-    # let response = client.put(request)
+    # var response = client.put(request)
     # testing.assert_equal(response.header.status_code(), 200)
 
 
@@ -138,10 +138,10 @@ fn test_request_patch[T: Client](inout client: T) raises -> None:
     WIP: Test making a PATCH request.
     Validate that the PATCH request is properly received and the server can parse the body.
     """
-    let uri = URI("http", "localhost", "/123")
-    let request = HTTPRequest(uri)
+    var uri = URI("http", "localhost", "/123")
+    var request = HTTPRequest(uri)
     # request.body = "foo=bar&baz=qux"
-    # let response = client.patch(request)
+    # var response = client.patch(request)
     # testing.assert_equal(response.header.status_code(), 200)
 
 
@@ -150,10 +150,10 @@ fn test_request_options[T: Client](inout client: T) raises -> None:
     WIP: Test making an OPTIONS request.
     Validate that the OPTIONS request is properly received and the server can parse the body.
     """
-    let uri = URI("http", "localhost", "/123")
-    let request = HTTPRequest(uri)
+    var uri = URI("http", "localhost", "/123")
+    var request = HTTPRequest(uri)
     # request.body = "foo=bar&baz=qux"
-    # let response = client.options(request)
+    # var response = client.options(request)
     # testing.assert_equal(response.header.status_code(), 200)
 
 
@@ -162,10 +162,10 @@ fn test_request_delete[T: Client](inout client: T) raises -> None:
     WIP: Test making a DELETE request.
     Validate that the DELETE request is properly received and the server can parse the body.
     """
-    let uri = URI("http", "localhost", "/123")
-    let request = HTTPRequest(uri)
+    var uri = URI("http", "localhost", "/123")
+    var request = HTTPRequest(uri)
     # request.body = "foo=bar&baz=qux"
-    # let response = client.delete(request)
+    # var response = client.delete(request)
     # testing.assert_equal(response.header.status_code(), 200)
 
 
@@ -174,7 +174,7 @@ fn test_request_head[T: Client](inout client: T) raises -> None:
     WIP: Test making a HEAD request.
     Validate that the HEAD request is properly received and the server can parse the body.
     """
-    let uri = URI("http", "localhost", "/123")
-    let request = HTTPRequest(uri)
-    # let response = client.head(request)
+    var uri = URI("http", "localhost", "/123")
+    var request = HTTPRequest(uri)
+    # var response = client.head(request)
     # testing.assert_equal(response.header.status_code(), 200)

--- a/lightbug_http/tests/test_connection.mojo
+++ b/lightbug_http/tests/test_connection.mojo
@@ -9,11 +9,11 @@ fn test_multiple_connections[T: Client](inout client: T) raises -> None:
     WIP: Test making multiple simultaneous connections.
     Validate that the server can handle multiple simultaneous connections without dropping or mixing up data.
     """
-    let uri = URI("http", "localhost", "/123")
-    let request = HTTPRequest(uri)
-    # let response1 = client.get(request)
-    # let response2 = client.get(request)
-    # let response3 = client.get(request)
+    var uri = URI("http", "localhost", "/123")
+    var request = HTTPRequest(uri)
+    # var response1 = client.get(request)
+    # var response2 = client.get(request)
+    # var response3 = client.get(request)
     # testing.assert_equal(response1.header.status_code(), 200)
     # testing.assert_equal(response2.header.status_code(), 200)
     # testing.assert_equal(response3.header.status_code(), 200)
@@ -24,9 +24,9 @@ fn test_idle_connections[T: Client](inout client: T) raises -> None:
     WIP: Test idle connections.
     Establish a connection and then remain idle for longer than the server’s timeout setting to ensure the server properly closes the connection.
     """
-    let uri = URI("http", "localhost", "/123")
-    let request = HTTPRequest(uri)
-    # let response = client.get(request)
+    var uri = URI("http", "localhost", "/123")
+    var request = HTTPRequest(uri)
+    # var response = client.get(request)
     # testing.assert_equal(response.header.status_code(), 200)
 
 

--- a/lightbug_http/tests/test_cookies.mojo
+++ b/lightbug_http/tests/test_cookies.mojo
@@ -9,9 +9,9 @@ fn test_request_with_cookies[T: Client](inout client: T) raises -> None:
     WIP: Test making a simple GET request with cookies.
     Validate that the cookies are parsed correctly.
     """
-    let uri = URI("http", "localhost", "/123")
-    # let cookies = [Cookie("foo", "bar")]
-    # let response = client.get(HTTPRequest(uri, cookies=cookies))
+    var uri = URI("http", "localhost", "/123")
+    # var cookies = [Cookie("foo", "bar")]
+    # var response = client.get(HTTPRequest(uri, cookies=cookies))
     # testing.assert_equal(response.header.status_code(), 200)
 
 
@@ -20,12 +20,12 @@ fn test_request_with_invalid_cookies[T: Client](inout client: T) raises -> None:
     WIP:  We should be able to parse invalid or non-spec conformant cookies, such as the ones set by Okta (see below).
     From Starlette (https://github.com/encode/starlette/blob/master/tests/test_requests.py).
     """
-    let uri = URI("http", "localhost", "/123")
-    # let cookies = [
+    var uri = URI("http", "localhost", "/123")
+    # var cookies = [
     #     Cookie("importantCookie", "importantValue"),
     #     Cookie("okta-oauth-redirect-params", '{"responseType":"code","state":"somestate","nonce":"somenonce","scopes":["openid","profile","email","phone"],"urls":{"issuer":"https://subdomain.okta.com/oauth2/authServer","authorizeUrl":"https://subdomain.okta.com/oauth2/authServer/v1/authorize","userinfoUrl":"https://subdomain.okta.com/oauth2/authServer/v1/userinfo"}}'),
     #     Cookie("provider-oauth-nonce", "validAsciiblabla"),
     #     Cookie("sessionCookie", "importantSessionValue"),
     # ]
-    # let response = client.get(HTTPRequest(uri, cookies=cookies))
+    # var response = client.get(HTTPRequest(uri, cookies=cookies))
     # testing.assert_equal(response.header.status_code(), 200)

--- a/lightbug_http/tests/test_fd.mojo
+++ b/lightbug_http/tests/test_fd.mojo
@@ -8,26 +8,26 @@ fn test_fd_basic_io():
     Validates that the file descriptor can be opened, written to, and read from.
     """
 
-    let file_path: StringLiteral = "./static/test.txt"
+    var file_path: StringLiteral = "./static/test.txt"
 
     # Open a file for writing
-    let fd = FileDescriptor(file_path)
+    var fd = FileDescriptor(file_path)
 
     # Writing to the file descriptor
-    let data_to_write = "Hello, Mojo! 日本人 中國的 ~=[]()%+{}@;’#!$_&-  éè  ;∞¥₤€"  # Sample data to write, with non-ASCII characters
+    var data_to_write = "Hello, Mojo! 日本人 中國的 ~=[]()%+{}@;’#!$_&-  éè  ;∞¥₤€"  # Sample data to write, with non-ASCII characters
     try:
-        let num_bytes_written = fd.write(data_to_write)
+        var num_bytes_written = fd.write(data_to_write)
         print("Written bytes:" + num_bytes_written.__str__())
     except IOError:
         print("Error writing to file: (e)")
 
     # fd.__del__() is automatically called when fd goes out of scope
-    let fd_read = FileDescriptor(file_path)
+    var fd_read = FileDescriptor(file_path)
 
     # Reading from the file descriptor
     # Initialize a buffer for reading; ensure it's large enough for the expected data
     try:
-        let content = fd_read.read()
+        var content = fd_read.read()
         print("File contents:" + content)
     except IOError:
         print("Error reading from file: (e)")

--- a/lightbug_http/tests/test_io.mojo
+++ b/lightbug_http/tests/test_io.mojo
@@ -3,7 +3,7 @@ from lightbug_http.io.bytes import Bytes, bytes_equal
 
 
 fn test_bytes_equal() raises:
-    let test1 = String("test")._buffer
-    let test2 = String("test")._buffer
-    let equal = bytes_equal(test1, test2)
+    var test1 = String("test")._buffer
+    var test2 = String("test")._buffer
+    var equal = bytes_equal(test1, test2)
     testing.assert_true(equal)

--- a/lightbug_http/tests/test_server.mojo
+++ b/lightbug_http/tests/test_server.mojo
@@ -20,8 +20,8 @@ fn test_python_server[C: Client](client: C, ln: PythonListenConfig) raises -> No
     Validate that the server is listening on the provided port.
     """
     ...
-    # let conn = ln.accept()
-    # let res = client.do(
+    # var conn = ln.accept()
+    # var res = client.do(
     #     HTTPRequest(
     #         URI(default_server_conn_string),
     #         String("Hello world!")._buffer,

--- a/lightbug_http/tests/utils.mojo
+++ b/lightbug_http/tests/utils.mojo
@@ -28,7 +28,7 @@ alias defaultExpectedGetResponse = String(
 @parameter
 fn new_httpx_client() -> PythonObject:
     try:
-        let httpx = Python.import_module("httpx")
+        var httpx = Python.import_module("httpx")
         return httpx
     except e:
         print("Could not set up httpx client: " + e.__str__())
@@ -89,14 +89,14 @@ struct FakeClient(Client):
 
         self.req_full_uri = full_uri
 
-        let host = String(full_uri.host())
+        var host = String(full_uri.host())
 
         if host == "":
             raise Error("URI host is nil")
 
         self.req_host = host
 
-        let is_tls = full_uri.is_https()
+        var is_tls = full_uri.is_https()
         self.req_is_tls = is_tls
 
         return ReqInfo(full_uri, host, is_tls)
@@ -139,7 +139,7 @@ struct FakeServer(ServerTrait):
 @value
 struct FakeResponder(HTTPService):
     fn func(self, req: HTTPRequest) raises -> HTTPResponse:
-        let method = String(req.header.method())
+        var method = String(req.header.method())
         if method != "GET":
             raise Error("Did not expect a non-GET request! Got: " + method)
         return OK(String("Hello, world!")._buffer)

--- a/lightbug_http/uri.mojo
+++ b/lightbug_http/uri.mojo
@@ -162,7 +162,7 @@ struct URI:
         return self.__host
 
     fn parse(inout self) raises -> None:
-        let raw_uri = String(self.__full_uri)
+        var raw_uri = String(self.__full_uri)
 
         # Defaults to HTTP/1.1
         var proto_str = String(strHttp11)
@@ -175,7 +175,7 @@ struct URI:
         elif n == 0:
             raise Error("Request URI cannot be empty")
         else:
-            let proto = raw_uri[n + 1 :]
+            var proto = raw_uri[n + 1 :]
             if proto != strHttp11:
                 proto_str = proto
 
@@ -184,7 +184,7 @@ struct URI:
         # Parse host from requestURI
         n = request_uri.find("://")
         if n >= 0:
-            let host_and_port = request_uri[n + 3 :]
+            var host_and_port = request_uri[n + 3 :]
             n = host_and_port.find("/")
             if n >= 0:
                 self.__host = host_and_port[:n]._buffer


### PR DESCRIPTION
Change `let` to `var` to remove warnings, and change trait return type to a concrete type to fix error