### PR TITLE
DRAFT: Add functions to get peer name for raddr.

### DIFF
--- a/external/libc.mojo
+++ b/external/libc.mojo
@@ -555,6 +555,48 @@ fn setsockopt(
     ](socket, level, option_name, option_value, option_len)
 
 
+fn getsockname(
+    socket: c_int, address: Pointer[sockaddr], address_len: Pointer[socklen_t]
+) -> c_int:
+    """Libc POSIX `getsockname` function
+    Reference: https://man7.org/linux/man-pages/man3/getsockname.3p.html
+    Fn signature: int getsockname(int socket, struct sockaddr *restrict address, socklen_t *restrict address_len).
+
+    Args: socket: A File Descriptor.
+        address: A pointer to a buffer to store the address of the peer.
+        address_len: A pointer to the size of the buffer.
+    Returns: 0 on success, -1 on error.
+    """
+    return external_call[
+        "getsockname",
+        c_int,  # FnName, RetType
+        c_int,
+        Pointer[sockaddr],
+        Pointer[socklen_t],  # Args
+    ](socket, address, address_len)
+
+
+fn getpeername(
+    sockfd: c_int, addr: Pointer[sockaddr], address_len: Pointer[socklen_t]
+) -> c_int:
+    """Libc POSIX `getpeername` function
+    Reference: https://man7.org/linux/man-pages/man2/getpeername.2.html
+    Fn signature:   int getpeername(int socket, struct sockaddr *restrict addr, socklen_t *restrict address_len).
+
+    Args: sockfd: A File Descriptor.
+        addr: A pointer to a buffer to store the address of the peer.
+        address_len: A pointer to the size of the buffer.
+    Returns: 0 on success, -1 on error.
+    """
+    return external_call[
+        "getpeername",
+        c_int,  # FnName, RetType
+        c_int,
+        Pointer[sockaddr],
+        Pointer[socklen_t],  # Args
+    ](sockfd, addr, address_len)
+
+
 fn bind(socket: c_int, address: Pointer[sockaddr], address_len: socklen_t) -> c_int:
     """Libc POSIX `bind` function
     Reference: https://man7.org/linux/man-pages/man3/bind.3p.html

--- a/lightbug_http/net.mojo
+++ b/lightbug_http/net.mojo
@@ -8,7 +8,7 @@ alias default_tcp_keep_alive = Duration(15 * 1000 * 1000 * 1000)  # 15 seconds
 
 
 trait Net(DefaultConstructible):
-    fn __init__(inout self):
+    fn __init__(inout self) raises:
         ...
 
     fn __init__(inout self, keep_alive: Duration) raises:

--- a/lightbug_http/net.mojo
+++ b/lightbug_http/net.mojo
@@ -8,7 +8,7 @@ alias default_tcp_keep_alive = Duration(15 * 1000 * 1000 * 1000)  # 15 seconds
 
 
 trait Net(DefaultConstructible):
-    fn __init__(inout self) raises:
+    fn __init__(inout self):
         ...
 
     fn __init__(inout self, keep_alive: Duration) raises:

--- a/lightbug_http/sys/net.mojo
+++ b/lightbug_http/sys/net.mojo
@@ -7,7 +7,6 @@ from lightbug_http.net import (
     resolve_internet_addr,
     default_buffer_size,
     default_tcp_keep_alive,
-    HostPort,
     get_peer_name,
 )
 from lightbug_http.strings import NetworkType

--- a/lightbug_http/sys/net.mojo
+++ b/lightbug_http/sys/net.mojo
@@ -7,6 +7,7 @@ from lightbug_http.net import (
     resolve_internet_addr,
     default_buffer_size,
     default_tcp_keep_alive,
+    HostPort
 )
 from lightbug_http.strings import NetworkType
 from lightbug_http.io.bytes import Bytes
@@ -37,7 +38,84 @@ from external.libc import (
     bind,
     shutdown,
     close,
+    getsockname,
+    getpeername,
+    ntohs,
+    inet_ntop
 )
+
+
+fn convert_binary_port_to_int(port: UInt16) -> Int:
+    return int(ntohs(port))
+
+
+fn convert_binary_ip_to_string(
+    owned ip_address: UInt32, address_family: Int32, address_length: UInt32
+) -> String:
+    """Convert a binary IP address to a string by calling inet_ntop.
+
+    Args:
+        ip_address: The binary IP address.
+        address_family: The address family of the IP address.
+        address_length: The length of the address.
+
+    Returns:
+        The IP address as a string.
+    """
+    # It seems like the len of the buffer depends on the length of the string IP.
+    # Allocating 10 works for localhost (127.0.0.1) which I suspect is 9 bytes + 1 null terminator byte. So max should be 16 (15 + 1).
+    var ip_buffer = Pointer[c_void].alloc(16)
+    var ip_address_ptr = Pointer.address_of(ip_address).bitcast[c_void]()
+    _ = inet_ntop(address_family, ip_address_ptr, ip_buffer, 16)
+
+    var string_buf = ip_buffer.bitcast[Int8]()
+    var index = 0
+    while True:
+        if string_buf[index] == 0:
+            break
+        index += 1
+
+    return StringRef(string_buf, index)
+
+
+fn get_sock_name(fd: Int32) raises -> HostPort:
+    """Return the address of the socket."""
+    var local_address_ptr = Pointer[sockaddr].alloc(1)
+    var local_address_ptr_size = socklen_t(sizeof[sockaddr]())
+    var status = getsockname(
+        fd,
+        local_address_ptr,
+        Pointer[socklen_t].address_of(local_address_ptr_size),
+    )
+    if status == -1:
+        raise Error("get_sock_name: Failed to get address of local socket.")
+    var addr_in = local_address_ptr.bitcast[sockaddr_in]().load()
+
+    return HostPort(
+        host=convert_binary_ip_to_string(addr_in.sin_addr.s_addr, AF_INET, 16),
+        port=convert_binary_port_to_int(addr_in.sin_port),
+    )
+
+
+fn get_peer_name(fd: Int32) raises -> HostPort:
+    """Return the address of the peer connected to the socket."""
+    var remote_address_ptr = Pointer[sockaddr].alloc(1)
+    var remote_address_ptr_size = socklen_t(sizeof[sockaddr]())
+    var status = getpeername(
+        fd,
+        remote_address_ptr,
+        Pointer[socklen_t].address_of(remote_address_ptr_size),
+    )
+    if status == -1:
+        raise Error("get_peer_name: Failed to get address of remote socket.")
+
+    # Cast sockaddr struct to sockaddr_in to convert binary IP to string.
+    var addr_in = remote_address_ptr.bitcast[sockaddr_in]().load()
+
+    return HostPort(
+        host=convert_binary_ip_to_string(addr_in.sin_addr.s_addr, AF_INET, 16),
+        port=convert_binary_port_to_int(addr_in.sin_port),
+    )
 
 
 @value
@@ -65,8 +143,9 @@ struct SysListener(Listener):
         )
         if new_sockfd == -1:
             print("Failed to accept connection")
-        # TODO: pass raddr to connection
-        return SysConnection(self.__addr, TCPAddr("", 0), new_sockfd)
+        var peer = get_peer_name(new_sockfd)
+
+        return SysConnection(self.__addr, TCPAddr(peer.host, atol(peer.port)), new_sockfd)
 
     fn close(self) raises:
         _ = shutdown(self.fd, SHUT_RDWR)

--- a/lightbug_http/sys/net.mojo
+++ b/lightbug_http/sys/net.mojo
@@ -7,7 +7,8 @@ from lightbug_http.net import (
     resolve_internet_addr,
     default_buffer_size,
     default_tcp_keep_alive,
-    HostPort
+    HostPort,
+    get_peer_name,
 )
 from lightbug_http.strings import NetworkType
 from lightbug_http.io.bytes import Bytes
@@ -38,84 +39,7 @@ from external.libc import (
     bind,
     shutdown,
     close,
-    getsockname,
-    getpeername,
-    ntohs,
-    inet_ntop
 )
-
-
-fn convert_binary_port_to_int(port: UInt16) -> Int:
-    return int(ntohs(port))
-
-
-fn convert_binary_ip_to_string(
-    owned ip_address: UInt32, address_family: Int32, address_length: UInt32
-) -> String:
-    """Convert a binary IP address to a string by calling inet_ntop.
-
-    Args:
-        ip_address: The binary IP address.
-        address_family: The address family of the IP address.
-        address_length: The length of the address.
-
-    Returns:
-        The IP address as a string.
-    """
-    # It seems like the len of the buffer depends on the length of the string IP.
-    # Allocating 10 works for localhost (127.0.0.1) which I suspect is 9 bytes + 1 null terminator byte. So max should be 16 (15 + 1).
-    var ip_buffer = Pointer[c_void].alloc(16)
-    var ip_address_ptr = Pointer.address_of(ip_address).bitcast[c_void]()
-    _ = inet_ntop(address_family, ip_address_ptr, ip_buffer, 16)
-
-    var string_buf = ip_buffer.bitcast[Int8]()
-    var index = 0
-    while True:
-        if string_buf[index] == 0:
-            break
-        index += 1
-
-    return StringRef(string_buf, index)
-
-
-fn get_sock_name(fd: Int32) raises -> HostPort:
-    """Return the address of the socket."""
-    var local_address_ptr = Pointer[sockaddr].alloc(1)
-    var local_address_ptr_size = socklen_t(sizeof[sockaddr]())
-    var status = getsockname(
-        fd,
-        local_address_ptr,
-        Pointer[socklen_t].address_of(local_address_ptr_size),
-    )
-    if status == -1:
-        raise Error("get_sock_name: Failed to get address of local socket.")
-    var addr_in = local_address_ptr.bitcast[sockaddr_in]().load()
-
-    return HostPort(
-        host=convert_binary_ip_to_string(addr_in.sin_addr.s_addr, AF_INET, 16),
-        port=convert_binary_port_to_int(addr_in.sin_port),
-    )
-
-
-fn get_peer_name(fd: Int32) raises -> HostPort:
-    """Return the address of the peer connected to the socket."""
-    var remote_address_ptr = Pointer[sockaddr].alloc(1)
-    var remote_address_ptr_size = socklen_t(sizeof[sockaddr]())
-    var status = getpeername(
-        fd,
-        remote_address_ptr,
-        Pointer[socklen_t].address_of(remote_address_ptr_size),
-    )
-    if status == -1:
-        raise Error("get_peer_name: Failed to get address of remote socket.")
-
-    # Cast sockaddr struct to sockaddr_in to convert binary IP to string.
-    var addr_in = remote_address_ptr.bitcast[sockaddr_in]().load()
-
-    return HostPort(
-        host=convert_binary_ip_to_string(addr_in.sin_addr.s_addr, AF_INET, 16),
-        port=convert_binary_port_to_int(addr_in.sin_port),
-    )
 
 
 @value

--- a/lightbug_http/sys/server.mojo
+++ b/lightbug_http/sys/server.mojo
@@ -62,7 +62,6 @@ struct SysServer:
 
         while True:
             var conn = self.ln.accept()
-            print("Remote address:", conn.raddr.ip, conn.laddr.port)
             var buf = Bytes()
             var read_len = conn.read(buf)
             var first_line_and_headers = next_line(buf)

--- a/lightbug_http/sys/server.mojo
+++ b/lightbug_http/sys/server.mojo
@@ -62,6 +62,7 @@ struct SysServer:
 
         while True:
             var conn = self.ln.accept()
+            print("Remote address:", conn.raddr.ip, conn.laddr.port)
             var buf = Bytes()
             var read_len = conn.read(buf)
             var first_line_and_headers = next_line(buf)


### PR DESCRIPTION
Hey @saviorand! I was working on porting over some of the `net` package for Go and was able to get the peer name for a connected socket. I figured you might want to incorporate it into your library for raddr, but I am not sure where the functions should live within your code.

I'm trying to test it with the latest code from main, but it seems like `SysNet` is running into some issues. The compiler says:

```
error: 'self.__lc' is uninitialized at the implicit return from this function
    fn __init__(inout self):
```