### PR TITLE
fix: support latest version of mojo

### DIFF
--- a/external/libc.mojo
+++ b/external/libc.mojo
@@ -37,7 +37,7 @@ alias char_pointer = AnyPointer[c_char]
 #     fn to_string(self, size: Int) -> String:
 #         var result: String = ""
 #         for i in range(size):
-#             result += chr(self.vector[i].to_int())
+#             result += chr(int(self.vector[i]))
 #         return result
 
 #     fn __enter__(owned self: Self) -> Self:
@@ -751,7 +751,7 @@ fn inet_pton(address_family: Int, address: String) -> Int:
     var conv_status = inet_pton(
         rebind[c_int](address_family), to_char_ptr(address), ip_buf
     )
-    return ip_buf.bitcast[c_uint]().load().to_int()
+    return int(ip_buf.bitcast[c_uint]().load())
 
 
 # --- ( File Related Syscalls & Structs )---------------------------------------

--- a/external/libc.mojo
+++ b/external/libc.mojo
@@ -13,37 +13,6 @@ alias GRND_NONBLOCK: UInt8 = 1
 
 alias char_pointer = AnyPointer[c_char]
 
-
-# @value
-# struct Str:
-#     var vector: List[c_char]
-
-#     fn __init__(inout self, string: String):
-#         self.vector = List[c_char](capacity=len(string) + 1)
-#         for i in range(len(string)):
-#             self.vector.push_back(ord(string[i]))
-#         self.vector.push_back(0)
-
-#     fn __init__(inout self, size: Int):
-#         self.vector = List[c_char]()
-#         self.vector.resize(size + 1, 0)
-
-#     fn __len__(self) -> Int:
-#         for i in range(len(self.vector)):
-#             if self.vector[i] == 0:
-#                 return i
-#         return -1
-
-#     fn to_string(self, size: Int) -> String:
-#         var result: String = ""
-#         for i in range(size):
-#             result += chr(int(self.vector[i]))
-#         return result
-
-#     fn __enter__(owned self: Self) -> Self:
-#         return self ^
-
-
 # Adapted from https://github.com/crisadamo/mojo-Libc . Huge thanks to Cristian!
 # C types
 alias c_void = UInt8

--- a/external/morrow.mojo
+++ b/external/morrow.mojo
@@ -51,7 +51,7 @@ struct TimeZone:
     @staticmethod
     fn local() -> TimeZone:
         var local_t = c_localtime(0)
-        return TimeZone(local_t.tm_gmtoff.to_int(), "local")
+        return TimeZone(int(local_t.tm_gmtoff), "local")
 
     @staticmethod
     fn from_utc(utc_str: String) raises -> TimeZone:
@@ -247,15 +247,15 @@ struct Morrow:
             tz = TimeZone(0, "UTC")
         else:
             tm = c_localtime(t.tv_sec)
-            tz = TimeZone(tm.tm_gmtoff.to_int(), "local")
+            tz = TimeZone(int(tm.tm_gmtoff), "local")
 
         var result = Self(
-            tm.tm_year.to_int() + 1900,
-            tm.tm_mon.to_int() + 1,
-            tm.tm_mday.to_int(),
-            tm.tm_hour.to_int(),
-            tm.tm_min.to_int(),
-            tm.tm_sec.to_int(),
+            int(tm.tm_year) + 1900,
+            int(tm.tm_mon) + 1,
+            int(tm.tm_mday),
+            int(tm.tm_hour),
+            int(tm.tm_min),
+            int(tm.tm_sec),
             t.tv_usec,
             tz,
         )
@@ -264,13 +264,13 @@ struct Morrow:
     @staticmethod
     fn fromtimestamp(timestamp: Float64) raises -> Self:
         var timestamp_ = normalize_timestamp(timestamp)
-        var t = CTimeval(timestamp_.to_int())
+        var t = CTimeval(int(timestamp_))
         return Self._fromtimestamp(t, False)
 
     @staticmethod
     fn utcfromtimestamp(timestamp: Float64) raises -> Self:
         var timestamp_ = normalize_timestamp(timestamp)
-        var t = CTimeval(timestamp_.to_int())
+        var t = CTimeval(int(timestamp_))
         return Self._fromtimestamp(t, True)
 
 

--- a/lightbug_http/__init__.mojo
+++ b/lightbug_http/__init__.mojo
@@ -4,5 +4,5 @@ from lightbug_http.sys.server import SysServer
 
 
 trait DefaultConstructible:
-    fn __init__(inout self):
+    fn __init__(inout self) raises:
         ...

--- a/lightbug_http/net.mojo
+++ b/lightbug_http/net.mojo
@@ -19,7 +19,7 @@ alias default_tcp_keep_alive = Duration(15 * 1000 * 1000 * 1000)  # 15 seconds
 
 
 trait Net(DefaultConstructible):
-    fn __init__(inout self):
+    fn __init__(inout self) raises:
         ...
 
     fn __init__(inout self, keep_alive: Duration) raises:

--- a/lightbug_http/sys/net.mojo
+++ b/lightbug_http/sys/net.mojo
@@ -128,10 +128,10 @@ struct SysListenConfig(ListenConfig):
     var __keep_alive: Duration
 
     fn __init__(inout self) raises:
-        self.__keep_alive = Duration(default_tcp_keep_alive)
+        self.__keep_alive = default_tcp_keep_alive
 
     fn __init__(inout self, keep_alive: Duration) raises:
-        self.__keep_alive = Duration(keep_alive)
+        self.__keep_alive = keep_alive
 
     fn listen(inout self, network: String, address: String) raises -> SysListener:
         var addr = resolve_internet_addr(network, address)
@@ -235,11 +235,8 @@ struct SysConnection(Connection):
 struct SysNet(Net):
     var __lc: SysListenConfig
 
-    fn __init__(inout self):
-        try:
-            self.__lc = SysListenConfig(default_tcp_keep_alive)
-        except e:
-            print("Could not initialize SysListenConfig: " + e.__str__())
+    fn __init__(inout self) raises:
+        self.__lc = SysListenConfig(default_tcp_keep_alive)
 
     fn __init__(inout self, keep_alive: Duration) raises:
         self.__lc = SysListenConfig(keep_alive)


### PR DESCRIPTION
- Removed the deprecated `to_int` and uses `int()` instead.
- Fixed an issue where `alias Duration = Int` caused errors when trying to initialize with another Duration which is not necessary.
- Constructor of `SysNet` had a path that wouldn't initialize the values because of a try catch block with no raises clause.  This should fail fast if it cannot be constructed.
