### PR TITLE
Catch exceptions from service handler and return internal error

### DIFF
--- a/integration_test_client.mojo
+++ b/integration_test_client.mojo
@@ -12,6 +12,7 @@ struct IntegrationTest:
         self.client = Client()
 
     fn test_redirect(inout self) raises:
+        print("Testing redirect...")
         var h = Headers(Header(HeaderKey.CONNECTION, 'keep-alive'))
         var res = self.client.do(HTTPRequest(u("redirect"), headers=h))
         assert_equal(res.status_code, StatusCode.OK)
@@ -19,15 +20,24 @@ struct IntegrationTest:
         assert_equal(res.headers[HeaderKey.CONNECTION], "keep-alive")
 
     fn test_close_connection(inout self) raises:
+        print("Testing close connection...")
         var h = Headers(Header(HeaderKey.CONNECTION, 'close'))
         var res = self.client.do(HTTPRequest(u("close-connection"), headers=h))
         assert_equal(res.status_code, StatusCode.OK)
         assert_equal(to_string(res.body_raw), "connection closed")
         assert_equal(res.headers[HeaderKey.CONNECTION], "close")
 
+    fn test_server_error(inout self) raises:
+        print("Testing internal server error...")
+        var res = self.client.do(HTTPRequest(u("error")))
+        assert_equal(res.status_code, StatusCode.INTERNAL_ERROR)
+        assert_equal(res.status_text, "Internal Server Error")
+
+
     fn run_tests(inout self) raises:
         self.test_redirect()
         self.test_close_connection()
+        self.test_server_error()
 
 fn main() raises:
     var test = IntegrationTest()

--- a/integration_test_server.mojo
+++ b/integration_test_server.mojo
@@ -2,7 +2,7 @@ from lightbug_http import *
 
 @value
 struct IntegerationTestService(HTTPService):
-    fn func(self, req: HTTPRequest) raises -> HTTPResponse:
+    fn func(inout self, req: HTTPRequest) raises -> HTTPResponse:
         var p = req.uri.path
         if p == "/redirect":
             return HTTPResponse(
@@ -16,10 +16,13 @@ struct IntegerationTestService(HTTPService):
             return OK("yay you made it")
         elif p == "/close-connection":
             return OK("connection closed")
+        elif p == "/error":
+            raise Error("oops")
 
         return NotFound("wrong")
 
 fn main() raises:
     var server = Server(tcp_keep_alive=True)
-    server.listen_and_serve("127.0.0.1:8080", IntegerationTestService())
+    var service = IntegerationTestService()
+    server.listen_and_serve("127.0.0.1:8080", service)
             

--- a/lightbug_http/cookie/expiration.mojo
+++ b/lightbug_http/cookie/expiration.mojo
@@ -52,5 +52,5 @@ struct Expiration(CollectionElement):
             elif not bool(self.datetime) and not bool(other.datetime):
                 return True
             return self.datetime.value().isoformat() == other.datetime.value().isoformat()
-            
+
         return True

--- a/lightbug_http/http/common_response.mojo
+++ b/lightbug_http/http/common_response.mojo
@@ -43,3 +43,12 @@ fn NotFound(path: String) -> HTTPResponse:
         headers=Headers(Header(HeaderKey.CONTENT_TYPE, "text/plain")),
         body_bytes=bytes("path " + path + " not found"),
     )
+
+
+fn InternalError() -> HTTPResponse:
+    return HTTPResponse(
+        bytes("Failed to process request"),
+        status_code=500,
+        headers=Headers(Header(HeaderKey.CONTENT_TYPE, "text/plain")),
+        status_text="Internal Server Error",
+    )

--- a/lightbug_http/http/response.mojo
+++ b/lightbug_http/http/response.mojo
@@ -24,6 +24,7 @@ struct StatusCode:
     alias TEMPORARY_REDIRECT = 307
     alias PERMANENT_REDIRECT = 308
     alias NOT_FOUND = 404
+    alias INTERNAL_ERROR = 500
 
 
 @value

--- a/lightbug_http/net.mojo
+++ b/lightbug_http/net.mojo
@@ -146,7 +146,7 @@ struct ListenConfig:
     fn __init__(inout self) raises:
         self.__keep_alive = default_tcp_keep_alive
 
-    fn __init__(inout self, keep_alive: Duration) raises:
+    fn __init__(inout self, keep_alive: Duration):
         self.__keep_alive = keep_alive
 
     fn listen(inout self, network: String, address: String) raises -> NoTLSListener:
@@ -272,10 +272,10 @@ struct SysConnection(Connection):
 struct SysNet:
     var __lc: ListenConfig
 
-    fn __init__(inout self) raises:
+    fn __init__(inout self):
         self.__lc = ListenConfig(default_tcp_keep_alive)
 
-    fn __init__(inout self, keep_alive: Duration) raises:
+    fn __init__(inout self, keep_alive: Duration):
         self.__lc = ListenConfig(keep_alive)
 
     fn listen(inout self, network: String, addr: String) raises -> NoTLSListener:


### PR DESCRIPTION
- Catch exceptions from service handler and return `500` error
- Fix integration test and add test case
- Contributes to #3