### PR TITLE
Allow TCP to send null-terminated buffers

### DIFF
--- a/lightbug_http/connection.mojo
+++ b/lightbug_http/connection.mojo
@@ -159,9 +159,6 @@ struct TCPConnection(Connection):
                 raise Error("TCPConnection.read: Failed to read data from connection.")
 
     fn write(self, buf: Span[Byte]) raises -> Int:
-        if buf[-1] == 0:
-            raise Error("TCPConnection.write: Buffer must not be null-terminated.")
-
         try:
             return self.socket.send(buf)
         except e:

--- a/lightbug_http/socket.mojo
+++ b/lightbug_http/socket.mojo
@@ -441,9 +441,6 @@ struct Socket[AddrType: Addr & ImplicitlyCopyable, address_family: AddressFamily
         self._remote_address = AddrType(remote[0], remote[1])
 
     fn send(self, buffer: Span[Byte]) raises -> Int:
-        if buffer[-1] == 0:
-            raise Error("Socket.send: Buffer must not be null-terminated.")
-
         try:
             return send(self.fd, buffer.unsafe_ptr(), len(buffer), 0)
         except e:


### PR DESCRIPTION
Compressed files are sometimes null-terminated, and there is no reason to prevent them from being sent over the wire.